### PR TITLE
Couple of things

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,106 +1,89 @@
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 // (MIT licensed)
-// Also based on https://github.com/modulesio/window-fetch/blob/master/src/blob.js
 
-const TYPE = Symbol('type');
-const CLOSED = Symbol('closed');
+const { Readable } = require('stream')
+
+const BUFFER = Symbol('buffer')
+const TYPE = Symbol('type')
 
 class Blob {
-    constructor() {
-        Object.defineProperty(this, Symbol.toStringTag, {
-            value: 'Blob',
-            writable: false,
-            enumerable: false,
-            configurable: true
-        });
+  constructor (blobParts = [], options = {}) {
+    this[TYPE] = ''
 
-        this[CLOSED] = false;
-        this[TYPE] = '';
+    const buffers = []
+    let size = 0
 
-        const blobParts = arguments[0];
-        const options = arguments[1];
-
-        const buffers = [];
-
-        if (blobParts) {
-            const a = blobParts;
-            const length = Number(a.length);
-            for (let i = 0; i < length; i++) {
-                const element = a[i];
-                let buffer;
-                if (element instanceof Buffer) {
-                    buffer = element;
-                } else if (ArrayBuffer.isView(element)) {
-                    buffer = Buffer.from(element.buffer, element.byteOffset, element.byteLength);
-                } else if (element instanceof ArrayBuffer) {
-                    buffer = Buffer.from(element);
-                } else if (element instanceof Blob) {
-                    buffer = element.buffer;
-                } else {
-                    buffer = Buffer.from(typeof element === 'string' ? element : String(element));
-                }
-                buffers.push(buffer);
-            }
-        }
-
-        this.buffer = Buffer.concat(buffers);
-
-        let type = options && options.type !== undefined && String(options.type).toLowerCase();
-        if (type && !/[^\u0020-\u007E]/.test(type)) {
-            this[TYPE] = type;
-        }
+    const a = blobParts
+    const length = Number(a.length)
+    for (let i = 0; i < length; i++) {
+      const element = a[i]
+      let buffer
+      if (element instanceof Buffer) {
+        buffer = element
+      } else if (ArrayBuffer.isView(element)) {
+        buffer = Buffer.from(element.buffer, element.byteOffset, element.byteLength)
+      } else if (element instanceof ArrayBuffer) {
+        buffer = Buffer.from(element)
+      } else if (element instanceof Blob) {
+        buffer = element[BUFFER]
+      } else {
+        buffer = Buffer.from(typeof element === 'string' ? element : String(element))
+      }
+      size += buffer.length
+      buffers.push(buffer)
     }
-    get size() {
-        return this[CLOSED] ? 0 : this.buffer.length;
-    }
-    get type() {
-        return this[TYPE];
-    }
-    get isClosed() {
-        return this[CLOSED];
-    }
-    slice() {
-        const size = this.size;
 
-        const start = arguments[0];
-        const end = arguments[1];
-        let relativeStart, relativeEnd;
-        if (start === undefined) {
-            relativeStart = 0;
-        } else if (start < 0) {
-            relativeStart = Math.max(size + start, 0);
-        } else {
-            relativeStart = Math.min(start, size);
-        }
-        if (end === undefined) {
-            relativeEnd = size;
-        } else if (end < 0) {
-            relativeEnd = Math.max(size + end, 0);
-        } else {
-            relativeEnd = Math.min(end, size);
-        }
-        const span = Math.max(relativeEnd - relativeStart, 0);
+    this[BUFFER] = Buffer.concat(buffers, size)
 
-        const buffer = this.buffer;
-        const slicedBuffer = buffer.slice(
-            relativeStart,
-            relativeStart + span
-        );
-        const blob = new Blob([], { type: arguments[2] });
-        blob.buffer = slicedBuffer;
-        blob[CLOSED] = this[CLOSED];
-        return blob;
+    let type = options.type !== undefined && String(options.type).toLowerCase()
+    if (type && !/[^\u0020-\u007E]/.test(type)) {
+      this[TYPE] = type
     }
-    close() {
-        this[CLOSED] = true;
-    }
-};
+  }
+  get size () {
+    return this[BUFFER].length
+  }
+  get type () {
+    return this[TYPE]
+  }
+  text () {
+    return Promise.resolve(this[BUFFER].toString())
+  }
+  arrayBuffer () {
+    const buf = this[BUFFER]
+    const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+    return Promise.resolve(ab)
+  }
+  stream () {
+    const readable = new Readable()
+    readable._read = () => {}
+    readable.push(this[BUFFER])
+    readable.push(null)
+    return readable
+  }
+  toString () {
+    return '[object Blob]'
+  }
+  slice (start = 0, end = this.size, type = '') {
+    const buffer = this[BUFFER]
+    const slicedBuffer = buffer.slice(start, end)
+    const blob = new Blob([], { type })
+    blob[BUFFER] = slicedBuffer
+    return blob
+  }
+}
+
+Object.defineProperties(Blob.prototype, {
+  size: { enumerable: true },
+  type: { enumerable: true },
+  slice: { enumerable: true }
+})
 
 Object.defineProperty(Blob.prototype, Symbol.toStringTag, {
-    value: 'BlobPrototype',
-    writable: false,
-    enumerable: false,
-    configurable: true
-});
+  value: 'Blob',
+  writable: false,
+  enumerable: false,
+  configurable: true
+})
 
-module.exports = Blob;
+module.exports = Blob


### PR DESCRIPTION
- Symbol.toStringTag should be `Blob` not `BlobPrototype`
- toString() was missing
- close and isClosed is gone from the spec
- new reading method are available now in the spec. namely `string() arrayBuffer() & stream()`
- `this.buffer` should not be publicly available, so i put it in a symbol also. (all doe i maybe would have put internal/private things in a weakMap but symbol can do just as well)
- slice could be simplified as buffer.slice dose the same thing.